### PR TITLE
Fixed argumented build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+ARG SERVER_NAME
+
+ARG VIRTUAL_REPO_NAME
+
 FROM ${SERVER_NAME}-${VIRTUAL_REPO_NAME}.jfrog.io/alpine:3.11.5
 
 CMD printf "\nCONGRATULATIONS!!!\n\nYou have just set up your first Docker repository with the new JFrog Platform!\n\n"


### PR DESCRIPTION
The best way to replace the variables is sending arguments from the docker build command (--build-arg). For this to work the arguments must be explicitly declared via the ARG command in the Dockerfile.